### PR TITLE
Adding unit test for US 2.4

### DIFF
--- a/lib/services/building_detection.dart
+++ b/lib/services/building_detection.dart
@@ -1,0 +1,34 @@
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import '../data/building_polygons.dart';
+
+/// Ray-casting point in polygon.
+/// Returns true if [point] is inside [polygon].
+bool pointInPolygon(LatLng point, List<LatLng> polygon) {
+  bool inside = false;
+
+  for (int i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    final xi = polygon[i].latitude;
+    final yi = polygon[i].longitude;
+    final xj = polygon[j].latitude;
+    final yj = polygon[j].longitude;
+
+    final intersects = ((yi > point.longitude) != (yj > point.longitude)) &&
+        (point.latitude <
+            (xj - xi) *
+                    (point.longitude - yi) /
+                    ((yj - yi) == 0 ? 1e-12 : (yj - yi)) +
+                xi);
+
+    if (intersects) inside = !inside;
+  }
+
+  return inside;
+}
+
+/// Finds the building polygon containing [userLocation], else null.
+BuildingPolygon? detectBuildingPoly(LatLng userLocation) {
+  for (final b in buildingPolygons) {
+    if (pointInPolygon(userLocation, b.points)) return b;
+  }
+  return null;
+}

--- a/lib/services/location/googlemaps_livelocation.dart
+++ b/lib/services/location/googlemaps_livelocation.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../../shared/widgets/map_search_bar.dart';
-
+import '../building_detection.dart';
 import '../../data/building_polygons.dart';
 import '../../shared/widgets/campus_toggle.dart';
 import '../../utils/geo.dart';
@@ -217,13 +217,6 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
     });
   }
 
-  BuildingPolygon? _detectBuildingPoly(LatLng userLocation) {
-    for (final b in buildingPolygons) {
-      if (pointInPolygon(userLocation, b.points)) return b;
-    }
-    return null;
-  }
-
   Set<Polygon> _createBuildingPolygons() {
     const burgundy = Color(0xFF800020);
     const selectedBlue = Color(0xFF7F83C3);
@@ -312,7 +305,7 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
       setState(() {
         _currentLocation = newLatLng;
         _currentCampus = detectCampus(newLatLng);
-        _currentBuildingPoly = _detectBuildingPoly(newLatLng);
+        _currentBuildingPoly = detectBuildingPoly(newLatLng);
       });
 
       _mapController?.animateCamera(
@@ -332,7 +325,7 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
       setState(() {
         _currentLocation = newLatLng;
         _currentCampus = detectCampus(newLatLng);
-        _currentBuildingPoly = _detectBuildingPoly(newLatLng);
+        _currentBuildingPoly = detectBuildingPoly(newLatLng);
       });
     });
   }

--- a/test/current_building_test.dart
+++ b/test/current_building_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+import 'package:campus_app/data/building_polygons.dart';
+import 'package:campus_app/services/building_detection.dart';
+
+void main() {
+  group('US 2.3 - Show current user building location', () {
+    test('pointInPolygon returns true for a point inside LB polygon', () {
+      final lb = buildingPolygons.firstWhere((b) => b.code == "LB");
+
+      // Choose a point that should be inside LB (you can tweak if needed)
+      const insidePoint = LatLng(45.49680, -73.57790);
+
+      expect(pointInPolygon(insidePoint, lb.points), isTrue);
+    });
+
+    test('pointInPolygon returns false for a far away point', () {
+      final lb = buildingPolygons.firstWhere((b) => b.code == "LB");
+
+      const farAway = LatLng(45.0, -73.0);
+
+      expect(pointInPolygon(farAway, lb.points), isFalse);
+    });
+
+    test('detectBuildingPoly returns the correct building when inside one', () {
+      // Pick a point likely inside LB
+      const user = LatLng(45.49680, -73.57790);
+
+      final detected = detectBuildingPoly(user);
+
+      expect(detected, isNotNull);
+      expect(detected!.code, "LB");
+    });
+
+    test('detectBuildingPoly returns null when user is outside all polygons', () {
+      const user = LatLng(45.0, -73.0);
+
+      final detected = detectBuildingPoly(user);
+
+      expect(detected, isNull);
+    });
+
+    test('detectBuildingPoly returns the first match when overlapping occurs', () {
+      // This test is about behavior, not geography.
+      // If two polygons overlap (rare but possible), your loop returns the first matching polygon.
+      // We simulate overlap by creating two simple squares.
+      final polyA = BuildingPolygon(
+        code: "A",
+        name: "A",
+        points: const [
+          LatLng(0, 0),
+          LatLng(0, 10),
+          LatLng(10, 10),
+          LatLng(10, 0),
+        ],
+      );
+
+      final polyB = BuildingPolygon(
+        code: "B",
+        name: "B",
+        points: const [
+          LatLng(0, 0),
+          LatLng(0, 10),
+          LatLng(10, 10),
+          LatLng(10, 0),
+        ],
+      );
+
+      const user = LatLng(5, 5);
+
+      // local version of detect for this test (so we don't depend on your real data)
+      BuildingPolygon? detectLocal(LatLng p, List<BuildingPolygon> polys) {
+        for (final b in polys) {
+          if (pointInPolygon(p, b.points)) return b;
+        }
+        return null;
+      }
+
+      final detected = detectLocal(user, [polyA, polyB]);
+      expect(detected!.code, "A");
+    });
+  });
+}


### PR DESCRIPTION

This pull request refactors the building detection logic to improve code organization and testability. The main changes include extracting the point-in-polygon and building detection functions into a new service file, updating their usage in the map location logic, and adding comprehensive unit tests for these functions.

**Refactoring and Code Organization:**

* Extracted the `pointInPolygon` and `detectBuildingPoly` functions into a new service file `building_detection.dart` for better separation of concerns and reusability.
* Updated imports and replaced the old inline `_detectBuildingPoly` method in `googlemaps_livelocation.dart` with the new `detectBuildingPoly` function from the service file. [[1]](diffhunk://#diff-0e52f878875f7d9b5ea1a756e2be95543e2d23d97958e644cb374d366515674aL7-R7) [[2]](diffhunk://#diff-0e52f878875f7d9b5ea1a756e2be95543e2d23d97958e644cb374d366515674aL220-L226) [[3]](diffhunk://#diff-0e52f878875f7d9b5ea1a756e2be95543e2d23d97958e644cb374d366515674aL315-R308) [[4]](diffhunk://#diff-0e52f878875f7d9b5ea1a756e2be95543e2d23d97958e644cb374d366515674aL335-R328)

**Testing Improvements:**

* Added a new test suite in `current_building_test.dart` to verify the correctness of `pointInPolygon` and `detectBuildingPoly`, including edge cases such as points inside, outside, and overlapping polygons.

Closes #55