### PR TITLE
BUG: Swap on location does not update Origin/Destination Room availability

### DIFF
--- a/lib/services/location/googlemaps_livelocation.dart
+++ b/lib/services/location/googlemaps_livelocation.dart
@@ -179,6 +179,8 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
   final Map<String, List<DirectionsRouteSegment>> _routeSegmentsByMode = {};
   String? _routeOriginBuildingCode;
   String? _routeDestinationBuildingCode;
+  bool _isOriginPoi = false;
+  bool _isDestinationPoi = false;
 
   final Map<String, List<NavigationStep>> _routeStepsByMode = {};
   // --- Navigation camera follow state ---
@@ -296,6 +298,8 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
         _routeDestinationText = place.name;
         _routeOriginBuildingCode = currentBuildingCode;
         _routeDestinationBuildingCode = selectedBuilding?.code;
+        _isOriginPoi = false;
+        _isDestinationPoi = false;
 
         // Prefill destination room only when explicitly provided (Calendar Go to Room).
         final requestedRoom = (place.roomCode ?? '').trim();
@@ -899,6 +903,8 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
       _routeDestinationText = poi.name;
       _routeOriginBuildingCode = currentBuildingCode;
       _routeDestinationBuildingCode = null;
+      _isOriginPoi = false;
+      _isDestinationPoi = true;
     });
 
     await _fetchRoutesAndDurations();
@@ -1024,6 +1030,8 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
           '${_selectedBuildingPoly?.name} - ${_selectedBuildingPoly?.code}';
       _routeOriginBuildingCode = currentBuildingCode;
       _routeDestinationBuildingCode = _selectedBuildingPoly?.code;
+      _isOriginPoi = false;
+      _isDestinationPoi = false;
       print(
         '[DEBUG] Route building codes: origin=$_routeOriginBuildingCode, destination=$_routeDestinationBuildingCode',
       );
@@ -1628,11 +1636,19 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
       final tempOriginLatLng = _routeOrigin;
       final tempDestination = _routeDestinationText;
       final tempDestinationLatLng = _routeDestination;
+      final tempIsOriginPoi = _isOriginPoi;
+      final tempIsDestinationPoi = _isDestinationPoi;
+      final tempOriginBuildingCode = _routeOriginBuildingCode;
+      final tempDestinationBuildingCode = _routeDestinationBuildingCode;
 
       _routeOriginText = tempDestination;
       _routeOrigin = tempDestinationLatLng;
       _routeDestinationText = tempOrigin;
       _routeDestination = tempOriginLatLng;
+      _isOriginPoi = tempIsDestinationPoi;
+      _isDestinationPoi = tempIsOriginPoi;
+      _routeOriginBuildingCode = tempDestinationBuildingCode;
+      _routeDestinationBuildingCode = tempOriginBuildingCode;
 
       _routeOriginSuggestions = [];
       _routeDestinationSuggestions = [];
@@ -1960,6 +1976,7 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
         _routeOriginText = displayText;
         _routeOriginSuggestions = [];
         _routeOriginBuildingCode = buildingCode;
+        _isOriginPoi = false;
         _originRoomController.clear();
       });
       print('[DEBUG] Calling _fetchRoute with new origin: $newOrigin');
@@ -2004,6 +2021,7 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
         _routeDestinationText = displayText;
         _routeDestinationSuggestions = [];
         _routeDestinationBuildingCode = buildingCode;
+        _isDestinationPoi = false;
         _destinationRoomController.clear();
       });
       await _fetchRoutesAndDurations();
@@ -2138,6 +2156,8 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
       _routeOriginText = currentLocationTag;
       _routeDestinationText = place.name;
       _selectedSearchResult = place;
+      _isOriginPoi = false;
+      _isDestinationPoi = false;
     });
 
     print(
@@ -2862,6 +2882,8 @@ class _OutdoorMapPageState extends State<OutdoorMapPage> {
                     _wheelchairRoutingDefaultEnabled,
                 originBuildingCode: _routeOriginBuildingCode,
                 destinationBuildingCode: _routeDestinationBuildingCode,
+                isOriginPoi: _isOriginPoi,
+                isDestinationPoi: _isDestinationPoi,
                 isConcordiaBuilding: (buildingCode) {
                   return buildingPolygons.any(
                     (b) => b.code.toUpperCase() == buildingCode.toUpperCase(),

--- a/lib/shared/widgets/route_preview_panel.dart
+++ b/lib/shared/widgets/route_preview_panel.dart
@@ -55,6 +55,8 @@ class RoutePreviewPanel extends StatefulWidget {
   final String? currentBuildingCode;
   final String? destinationBuildingCode;
   final Function(String buildingCode)? isConcordiaBuilding;
+  final bool isOriginPoi;
+  final bool isDestinationPoi;
   final TextEditingController originRoomController;
   final TextEditingController destinationRoomController;
   final Function(String buildingCode, String roomCode)? onStartValid;
@@ -92,6 +94,8 @@ class RoutePreviewPanel extends StatefulWidget {
     this.onOriginRoomSubmitted,
     this.indoorRepository,
     this.highContrastMode = false,
+    this.isOriginPoi = false,
+    this.isDestinationPoi = false,
     this.selectedTransitionMode,
     this.onTransitionModeChanged,
     this.wheelchairRoutingDefaultEnabled = false,
@@ -338,8 +342,9 @@ class _RoutePreviewPanelState extends State<RoutePreviewPanel> {
                           ],
                         ),
                       ),
-                      if (_isOriginConcordiaBuilding ||
-                          _isDestinationConcordiaBuilding)
+                      if ((_isOriginConcordiaBuilding ||
+                              _isDestinationConcordiaBuilding) &&
+                          !(widget.isOriginPoi && widget.isDestinationPoi))
                         Padding(
                           padding: const EdgeInsets.symmetric(
                             horizontal: 12,
@@ -352,8 +357,12 @@ class _RoutePreviewPanelState extends State<RoutePreviewPanel> {
                             originRoomController: widget.originRoomController,
                             destinationRoomController:
                                 widget.destinationRoomController,
-                            originEnabled: _isOriginConcordiaBuilding,
-                            destinationEnabled: _isDestinationConcordiaBuilding,
+                            originEnabled:
+                                _isOriginConcordiaBuilding &&
+                                !widget.isOriginPoi,
+                            destinationEnabled:
+                                _isDestinationConcordiaBuilding &&
+                                !widget.isDestinationPoi,
                             onOriginValid: widget.onStartValid,
                             onDestinationValid: widget.onDestinationValid,
                             onOriginRoomSubmitted: widget.onOriginRoomSubmitted,

--- a/test/widgets/route_preview_panel_test.dart
+++ b/test/widgets/route_preview_panel_test.dart
@@ -1,5 +1,6 @@
 import 'package:campus_app/data/building_names.dart';
 import 'package:campus_app/data/search_suggestion.dart';
+import 'package:campus_app/shared/widgets/rooms_field_section.dart';
 import 'package:campus_app/shared/widgets/route_preview_panel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -505,227 +506,233 @@ void main() {
       expect(find.text('Destination 2'), findsOneWidget);
     });
 
-    testWidgets('didUpdateWidget updates origin controller when originText changes', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: 'Origin A',
-              destinationText: 'Destination A',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: const [],
-              destinationSuggestions: const [],
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+    testWidgets(
+      'didUpdateWidget updates origin controller when originText changes',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Origin A',
+                destinationText: 'Destination A',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: 'Origin B',
-              destinationText: 'Destination A',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: const [],
-              destinationSuggestions: const [],
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Origin B',
+                destinationText: 'Destination A',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-      final startField = tester.widget<TextField>(find.byKey(const Key('start_field')));
-      expect(startField.controller?.text, 'Origin B');
-    });
+        final startField = tester.widget<TextField>(
+          find.byKey(const Key('start_field')),
+        );
+        expect(startField.controller?.text, 'Origin B');
+      },
+    );
 
-    testWidgets('didUpdateWidget updates destination controller when destinationText changes', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: 'Origin A',
-              destinationText: 'Destination A',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: const [],
-              destinationSuggestions: const [],
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+    testWidgets(
+      'didUpdateWidget updates destination controller when destinationText changes',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Origin A',
+                destinationText: 'Destination A',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: 'Origin A',
-              destinationText: 'Destination B',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: const [],
-              destinationSuggestions: const [],
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Origin A',
+                destinationText: 'Destination B',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-      final destinationField = tester.widget<TextField>(
-        find.byKey(const Key('destination_field')),
-      );
-      expect(destinationField.controller?.text, 'Destination B');
-    });
+        final destinationField = tester.widget<TextField>(
+          find.byKey(const Key('destination_field')),
+        );
+        expect(destinationField.controller?.text, 'Destination B');
+      },
+    );
 
-    testWidgets('didUpdateWidget updates origin suggestions visibility when list changes', (
-      WidgetTester tester,
-    ) async {
-      final updatedOriginSuggestions = [
-        SearchSuggestion.fromConcordiaBuilding(concordiaBuildingNames[0]),
-      ];
+    testWidgets(
+      'didUpdateWidget updates origin suggestions visibility when list changes',
+      (WidgetTester tester) async {
+        final updatedOriginSuggestions = [
+          SearchSuggestion.fromConcordiaBuilding(concordiaBuildingNames[0]),
+        ];
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: '',
-              destinationText: '',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: const [],
-              destinationSuggestions: const [],
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: '',
+                destinationText: '',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.tap(find.byKey(const Key('start_field')));
-      await tester.pumpAndSettle();
-      expect(find.text(updatedOriginSuggestions.first.name), findsNothing);
+        await tester.tap(find.byKey(const Key('start_field')));
+        await tester.pumpAndSettle();
+        expect(find.text(updatedOriginSuggestions.first.name), findsNothing);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: '',
-              destinationText: '',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: updatedOriginSuggestions,
-              destinationSuggestions: const [],
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: '',
+                destinationText: '',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: updatedOriginSuggestions,
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
-      expect(find.text(updatedOriginSuggestions.first.name), findsOneWidget);
-    });
+        await tester.pumpAndSettle();
+        expect(find.text(updatedOriginSuggestions.first.name), findsOneWidget);
+      },
+    );
 
-    testWidgets('didUpdateWidget updates destination suggestions visibility when list changes', (
-      WidgetTester tester,
-    ) async {
-      final updatedDestinationSuggestions = [
-        SearchSuggestion.fromGooglePlace(
-          name: 'Updated Place',
-          subtitle: 'Updated Address',
-          placeId: 'updated_place_id',
-        ),
-      ];
+    testWidgets(
+      'didUpdateWidget updates destination suggestions visibility when list changes',
+      (WidgetTester tester) async {
+        final updatedDestinationSuggestions = [
+          SearchSuggestion.fromGooglePlace(
+            name: 'Updated Place',
+            subtitle: 'Updated Address',
+            placeId: 'updated_place_id',
+          ),
+        ];
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: '',
-              destinationText: '',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: const [],
-              destinationSuggestions: const [],
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: '',
+                destinationText: '',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.tap(find.byKey(const Key('destination_field')));
-      await tester.pumpAndSettle();
-      expect(find.text('Updated Place'), findsNothing);
+        await tester.tap(find.byKey(const Key('destination_field')));
+        await tester.pumpAndSettle();
+        expect(find.text('Updated Place'), findsNothing);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: RoutePreviewPanel(
-              originText: '',
-              destinationText: '',
-              onClose: () {},
-              onSwitch: () {},
-              onOriginChanged: (_) {},
-              onDestinationChanged: (_) {},
-              onOriginSelected: (_) {},
-              onDestinationSelected: (_) {},
-              originSuggestions: const [],
-              destinationSuggestions: updatedDestinationSuggestions,
-              originRoomController: originRoomController,
-              destinationRoomController: destinationRoomController,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: '',
+                destinationText: '',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: updatedDestinationSuggestions,
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
-      expect(find.text('Updated Place'), findsOneWidget);
-    });
+        await tester.pumpAndSettle();
+        expect(find.text('Updated Place'), findsOneWidget);
+      },
+    );
 
     testWidgets('RoutePreviewPanel shows hint texts when fields are empty', (
       WidgetTester tester,
@@ -1096,5 +1103,273 @@ void main() {
       expect(destinationValidCalled, isTrue);
       expect(destinationSubmittedCalled, isTrue);
     });
+
+    testWidgets(
+      'Room fields hidden when both origin and destination are POIs',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Coffee Shop',
+                destinationText: 'Pharmacy',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+                originBuildingCode: 'HALL',
+                destinationBuildingCode: 'VE',
+                isOriginPoi: true,
+                isDestinationPoi: true,
+                isConcordiaBuilding: (_) => true,
+                indoorRepository: indoorRepository,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(RoomFieldsSection), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Room fields shown with origin enabled and destination disabled when destination is POI',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Hall Building - HALL',
+                destinationText: 'Coffee Shop',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+                originBuildingCode: 'HALL',
+                destinationBuildingCode: null,
+                isOriginPoi: false,
+                isDestinationPoi: true,
+                isConcordiaBuilding: (code) => code == 'HALL',
+                indoorRepository: indoorRepository,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(RoomFieldsSection), findsOneWidget);
+
+        final originRoomField = find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField && widget.controller == originRoomController,
+        );
+        final destRoomField = find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField &&
+              widget.controller == destinationRoomController,
+        );
+
+        expect(originRoomField, findsOneWidget);
+        expect(destRoomField, findsOneWidget);
+
+        final originTextField = tester.widget<TextField>(originRoomField);
+        final destTextField = tester.widget<TextField>(destRoomField);
+        expect(originTextField.enabled, isTrue);
+        expect(destTextField.enabled, isFalse);
+      },
+    );
+
+    testWidgets(
+      'Room fields shown with destination enabled and origin disabled when origin is POI',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Coffee Shop',
+                destinationText: 'Hall Building - HALL',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+                originBuildingCode: null,
+                destinationBuildingCode: 'HALL',
+                isOriginPoi: true,
+                isDestinationPoi: false,
+                isConcordiaBuilding: (code) => code == 'HALL',
+                indoorRepository: indoorRepository,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(RoomFieldsSection), findsOneWidget);
+
+        final originRoomField = find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField && widget.controller == originRoomController,
+        );
+        final destRoomField = find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField &&
+              widget.controller == destinationRoomController,
+        );
+
+        expect(originRoomField, findsOneWidget);
+        expect(destRoomField, findsOneWidget);
+
+        final originTextField = tester.widget<TextField>(originRoomField);
+        final destTextField = tester.widget<TextField>(destRoomField);
+        expect(originTextField.enabled, isFalse);
+        expect(destTextField.enabled, isTrue);
+      },
+    );
+
+    testWidgets(
+      'Room fields both enabled when neither origin nor destination is POI',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Hall Building - HALL',
+                destinationText: 'VE Building - VE',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+                originBuildingCode: 'HALL',
+                destinationBuildingCode: 'VE',
+                isOriginPoi: false,
+                isDestinationPoi: false,
+                isConcordiaBuilding: (code) => code == 'HALL' || code == 'VE',
+                indoorRepository: indoorRepository,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(RoomFieldsSection), findsOneWidget);
+
+        final originRoomField = find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField && widget.controller == originRoomController,
+        );
+        final destRoomField = find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField &&
+              widget.controller == destinationRoomController,
+        );
+
+        final originTextField = tester.widget<TextField>(originRoomField);
+        final destTextField = tester.widget<TextField>(destRoomField);
+        expect(originTextField.enabled, isTrue);
+        expect(destTextField.enabled, isTrue);
+      },
+    );
+
+    testWidgets('POI flags default to false when not specified', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RoutePreviewPanel(
+              originText: 'Hall Building - HALL',
+              destinationText: 'VE Building - VE',
+              onClose: () {},
+              onSwitch: () {},
+              onOriginChanged: (_) {},
+              onDestinationChanged: (_) {},
+              onOriginSelected: (_) {},
+              onDestinationSelected: (_) {},
+              originSuggestions: const [],
+              destinationSuggestions: const [],
+              originRoomController: originRoomController,
+              destinationRoomController: destinationRoomController,
+              originBuildingCode: 'HALL',
+              destinationBuildingCode: 'VE',
+              isConcordiaBuilding: (code) => code == 'HALL' || code == 'VE',
+              indoorRepository: indoorRepository,
+            ),
+          ),
+        ),
+      );
+
+      // Without POI flags, room fields should show and both be enabled
+      expect(find.byType(RoomFieldsSection), findsOneWidget);
+
+      final originRoomField = find.byWidgetPredicate(
+        (widget) =>
+            widget is TextField && widget.controller == originRoomController,
+      );
+      final destRoomField = find.byWidgetPredicate(
+        (widget) =>
+            widget is TextField &&
+            widget.controller == destinationRoomController,
+      );
+
+      final originTextField = tester.widget<TextField>(originRoomField);
+      final destTextField = tester.widget<TextField>(destRoomField);
+      expect(originTextField.enabled, isTrue);
+      expect(destTextField.enabled, isTrue);
+    });
+
+    testWidgets(
+      'Room fields hidden when no Concordia buildings even without POI flags',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RoutePreviewPanel(
+                originText: 'Some Place',
+                destinationText: 'Another Place',
+                onClose: () {},
+                onSwitch: () {},
+                onOriginChanged: (_) {},
+                onDestinationChanged: (_) {},
+                onOriginSelected: (_) {},
+                onDestinationSelected: (_) {},
+                originSuggestions: const [],
+                destinationSuggestions: const [],
+                originRoomController: originRoomController,
+                destinationRoomController: destinationRoomController,
+                originBuildingCode: null,
+                destinationBuildingCode: null,
+                isOriginPoi: false,
+                isDestinationPoi: false,
+                isConcordiaBuilding: (_) => false,
+                indoorRepository: indoorRepository,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(RoomFieldsSection), findsNothing);
+      },
+    );
   });
 }


### PR DESCRIPTION
This PR adds code to handle whether the room number options is available or not when selecting a POI.

Test cases:
1. School building to school building -> Behavior is unchanged, room and destination are available
2. POI to school building -> Origin room is greyed out, destination room is available
3. School building to POI -> Origin room is available, destination room is greyed out
4. POI to POI -> Room selection is collapsed (invisible to the user)

Side-note: Must also test that going from test 2 to test 3 using the swap option also updates which option is available/greyed out.

**Description**
When selecting a POI and a school building as Origin/Destination (or vice-versa), the user can only enter a room number on the school building. If the user selects the swap option, the availability of the room entry does not swap. 

**Steps to Reproduce**
- Run the project
- Select a POI as destination and a school building as origin (or vice-versa)
- Select the swap option

**Actual Result**
 
<img width="412" height="954" alt="image" src="https://github.com/user-attachments/assets/37503114-43f4-4ac1-98fc-70a1039d94c2" />

<img width="416" height="940" alt="image" src="https://github.com/user-attachments/assets/a66f20ab-d1c3-4291-8963-2a5ccdc8426c" />
